### PR TITLE
Adds support for Hash-like objects

### DIFF
--- a/lib/to_dots.rb
+++ b/lib/to_dots.rb
@@ -4,14 +4,13 @@ require_relative './array'
 
 module ToDots
   def self.to_dots(object, result = [], prefix = '')
-    case object
-    when ::Hash
+    if object.respond_to?(:to_hash)
       object.each do |key, value|
         to_dots(value, result, "#{prefix}#{'.' unless prefix.empty?}#{key}")
       end
-    when ::Array
-      object.each_with_index do |value, index|
-        to_dots(value, result, "#{prefix}")
+    elsif object.is_a?(Array)
+      object.each do |value|
+        to_dots(value, result, prefix.to_s)
       end
     else
       result << "#{prefix}.#{object}"

--- a/spec/to_dots_spec.rb
+++ b/spec/to_dots_spec.rb
@@ -1,7 +1,11 @@
+require 'delegate'
+
 RSpec.describe ToDots do
   it "has a version number" do
     expect(ToDots::VERSION).not_to be nil
   end
+
+  class HashDelegator < SimpleDelegator; end
 
   [
     [
@@ -27,7 +31,11 @@ RSpec.describe ToDots do
     [
       {foo: [{bar: :baz}, {baz: :bar}], baz: {bar: :foo}},
       ['foo.bar.baz', 'foo.baz.bar', 'baz.bar.foo']
-    ]
+    ],
+    [
+      {foo: [HashDelegator.new(bar: :baz), HashDelegator.new(baz: :bar)], baz: HashDelegator.new(bar: :foo)},
+      ['foo.bar.baz', 'foo.baz.bar', 'baz.bar.foo']
+    ],
   ].each do |(input,output)|
     it{ expect(described_class.to_dots(input)).to eq(output) }
   end


### PR DESCRIPTION
When given an object that for all intents and purposes acts as a hash, to_dots should output the correct string.

Example: Rails 6.1 introduces a new class that uses SimpleDelegator to decorate the standard hash class called DeprecationHandlingDetailsHash. It adds a couple of instance variables and delegates everything else to Hash.

Because it was not a Hash however, we would see something like this:

`{'users' => DeprecationHandlingDetailsHash.new({:base=>{[:error=> :failed_to_update}]})}`

Would serialize as ["user.{:base=>[{:error=>:failed_to_update}]}"] when we would expect ["user.base.error.failed_to_update"]

---

This is my first time opening a PR here, so please let me know if there is anything else required. 